### PR TITLE
More dependency stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,26 +15,26 @@
         "ext-openssl": "*",
         "ext-json": "*",
         "mhauri/base45": "^0.1.1",
-        "fgrosse/phpasn1": "^2.0@dev",
+        "fgrosse/phpasn1": "^2.1",
         "web-auth/cose-lib": "^3.3",
-        "guzzlehttp/guzzle": "^7.4",
-        "spomky-labs/cbor-php": "v2.0.x-dev",
+        "guzzlehttp/guzzle": "^6.5 || ^7.4",
+        "spomky-labs/cbor-php": "v2.1.x-dev",
         "thecodingmachine/safe": "^1.3"
     },
     "autoload": {
         "psr-4": {
-            "Grambas\\": "src"
+            "Grambas\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Grambas\\Test\\": "tests"
+            "Grambas\\Test\\": "tests/"
         }
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",
-        "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^0.12.37",
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpstan/phpstan": "^1.2",
         "friendsofphp/php-cs-fixer": "dev-master"
     },
     "authors": [

--- a/src/Cbor/CoseSign1Tag.php
+++ b/src/Cbor/CoseSign1Tag.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Grambas\Cbor;
 
 use CBOR\CBORObject;
-use CBOR\TagObject as Base;
+use CBOR\Tag;
 
-final class CoseSign1Tag extends Base
+final class CoseSign1Tag extends Tag
 {
     public static function getTagId(): int
     {
         return 18;
     }
 
-    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Base
+    public static function createFromLoadedData(int $additionalInformation, ?string $data, CBORObject $object): Tag
     {
         return new self($additionalInformation, $data, $object);
     }

--- a/tests/BusinessLogicRulesTest.php
+++ b/tests/BusinessLogicRulesTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Grambas\Test;
 
-use _PHPStan_76800bfb5\Nette\Utils\DateTime;
+use DateTime;
 use Grambas\Model\CertificateInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -19,9 +19,9 @@ class BusinessLogicRulesTest extends TestCase
         static::assertTrue($dcc->vaccination->isValid());
         static::assertTrue($dcc->isValidFor(CertificateInterface::VACCINATION));
 
-        static::assertFalse($dcc->isValidForDate(new \DateTime('now'), CertificateInterface::VACCINATION));
+        static::assertFalse($dcc->isValidForDate(new DateTime('now'), CertificateInterface::VACCINATION));
 
-        $now = new \DateTime();
+        $now = new DateTime();
         $dcc->getCurrentCertificate()->validFrom = (clone $now)->modify('- 2 hours');
         $dcc->getCurrentCertificate()->validTo = (clone $now)->modify('+ 2 hours');
         static::assertTrue($dcc->isValidForDate((clone $now), CertificateInterface::VACCINATION));
@@ -42,27 +42,27 @@ class BusinessLogicRulesTest extends TestCase
 
         static::assertFalse($dcc->vaccination->isFullyVaccinated());
         static::assertFalse($dcc->vaccination->isValid());
-        static::assertFalse($dcc->vaccination->isValidForDate(new \DateTime()));
+        static::assertFalse($dcc->vaccination->isValidForDate(new DateTime()));
         static::assertFalse($dcc->isValidFor(CertificateInterface::VACCINATION));
     }
 
     public function test_vaccine_expired(): void
     {
         $dcc = $this->decode('/CY/2DCode/raw/6.json');
-        $dcc->getCurrentCertificate()->validTo = (new \DateTime('now'))->modify('- 2 hours');
+        $dcc->getCurrentCertificate()->validTo = (new DateTime('now'))->modify('- 2 hours');
 
         static::assertTrue($dcc->vaccination->isFullyVaccinated());
-        static::assertFalse($dcc->isValidForDate(new \DateTime('now'), CertificateInterface::VACCINATION));
+        static::assertFalse($dcc->isValidForDate(new DateTime('now'), CertificateInterface::VACCINATION));
     }
 
     public function test_recovery_valid(): void
     {
         $dcc = $this->decode('/PL/1.3.0/2DCode/raw/10.json');
 
-        $dcc->recovery->validFrom = new \DateTime('today');
-        $dcc->recovery->validTo = (new \DateTime('now'))->add(new \DateInterval('P1D'));
+        $dcc->recovery->validFrom = new DateTime('today');
+        $dcc->recovery->validTo = (new DateTime('now'))->add(new \DateInterval('P1D'));
 
-        static::assertTrue($dcc->recovery->isValidForDate(new \DateTime('now')));
+        static::assertTrue($dcc->recovery->isValidForDate(new DateTime('now')));
         static::assertTrue($dcc->isValidFor(CertificateInterface::RECOVERY));
         static::assertTrue($dcc->isValidFor(CertificateInterface::VACCINATION | CertificateInterface::RECOVERY));
         static::assertFalse($dcc->isValidFor(CertificateInterface::VACCINATION));
@@ -72,10 +72,10 @@ class BusinessLogicRulesTest extends TestCase
     {
         $dcc = $this->decode('/PL/1.3.0/2DCode/raw/10.json');
 
-        $dcc->recovery->validFrom = (new \DateTime('now'))->modify('-2 hours');
-        $dcc->recovery->validTo = (new \DateTime('now'))->modify('+2 hours');
+        $dcc->recovery->validFrom = (new DateTime('now'))->modify('-2 hours');
+        $dcc->recovery->validTo = (new DateTime('now'))->modify('+2 hours');
 
-        static::assertTrue($dcc->recovery->isValidForDate(new \DateTime('now')));
+        static::assertTrue($dcc->recovery->isValidForDate(new DateTime('now')));
         static::assertTrue($dcc->isValidFor(CertificateInterface::RECOVERY));
         static::assertTrue($dcc->isValidFor(CertificateInterface::VACCINATION | CertificateInterface::RECOVERY));
         static::assertFalse($dcc->isValidFor(CertificateInterface::VACCINATION));
@@ -85,7 +85,7 @@ class BusinessLogicRulesTest extends TestCase
     {
         $dcc = $this->decode('/PL/1.3.0/2DCode/raw/10.json');
 
-        static::assertFalse($dcc->recovery->isValidForDate(new \DateTime('2010-10-10')));
+        static::assertFalse($dcc->recovery->isValidForDate(new DateTime('2010-10-10')));
     }
 
     public function test_naat_negative(): void
@@ -98,7 +98,7 @@ class BusinessLogicRulesTest extends TestCase
         static::assertFalse($dcc->isValidFor(CertificateInterface::RAPID_TEST));
 
         $dcc->test->sampleCollectionDate = (new DateTime())->modify('-30 Minutes');
-        static::assertTrue($dcc->isValidForDate(new \DateTime(), CertificateInterface::PCR_TEST));
+        static::assertTrue($dcc->isValidForDate(new DateTime(), CertificateInterface::PCR_TEST));
     }
 
     public function test_naat_positive(): void
@@ -109,7 +109,7 @@ class BusinessLogicRulesTest extends TestCase
         static::assertFalse($dcc->test->isNegative());
         static::assertFalse($dcc->isValidFor(CertificateInterface::PCR_TEST));
 
-        static::assertFalse($dcc->isValidForDate(new \DateTime(), CertificateInterface::PCR_TEST));
+        static::assertFalse($dcc->isValidForDate(new DateTime(), CertificateInterface::PCR_TEST));
     }
 
     public function test_naat_positive2(): void
@@ -126,7 +126,7 @@ class BusinessLogicRulesTest extends TestCase
     {
         $dcc = $this->decode('/HU/2DCode/raw/3.json');
 
-        $dcc->test->testResult = (new \DateTime('now'))->modify('+2 hours');
+        $dcc->test->testResult = (new DateTime('now'))->modify('+2 hours');
 
         static::assertTrue($dcc->test->isRapidTest());
         static::assertFalse($dcc->test->isNegative());


### PR DESCRIPTION
* add trailing slash for psr-4 load definitions
* add more stable fgrosse/phpasn1 dependency
* update spomky-labs/cbor-php version.
* Quality tools: phpstan version upgrade
* Quality tools: allow to use phpunit 8 version
* fixed wrong use statement for DateTime in tests
* replace depreciated TagObject from CBOR pacakge